### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/web/bundles/test
+/web/bundles/test2
 /app/bootstrap.php.cache
 /app/cache/*
 /app/config/parameters.yml


### PR DESCRIPTION
- Modify the default regex to not match hidden files

An `ArgumentError: invalid byte sequence in UTF-8` was raised if there was a binary file inside a directory. Those hidden files (with a `.rb`|`.js`... extension) were typically created by the filesystem.

| Q | A |
| --- | --- |
| Bug fix? | no, The exception will still be raised if a regular `.rb`, `.js`... contains binary text. This PR will be at least more convenient for the user, allowing him to run `rake stats` without first having to remove all those temporary files |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7 |
